### PR TITLE
replaced deprecated commonLabels fields

### DIFF
--- a/k8s/base/postgresql/kustomization.yaml
+++ b/k8s/base/postgresql/kustomization.yaml
@@ -4,13 +4,14 @@ kind: Kustomization
 metadata:
   name: postgresql-base
 
-commonLabels:
-  app.kubernetes.io/name: postgresql
-  app.kubernetes.io/instance: base-postgresql
-  app.kubernetes.io/version: "15.4"
-  app.kubernetes.io/component: database
-  app.kubernetes.io/part-of: solidity-security-platform
-  app.kubernetes.io/managed-by: kustomize
+labels:
+- pairs:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: base-postgresql
+    app.kubernetes.io/version: "15.4"
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: solidity-security-platform
+    app.kubernetes.io/managed-by: kustomize
 
 resources:
   - statefulset.yaml

--- a/k8s/base/prometheus/kustomization.yaml
+++ b/k8s/base/prometheus/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - servicemonitor.yaml
   - rbac.yaml
 
-commonLabels:
-  app.kubernetes.io/name: prometheus
-  app.kubernetes.io/part-of: monitoring
+labels:
+- pairs:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: monitoring

--- a/k8s/overlays/production/postgresql/kustomization.yaml
+++ b/k8s/overlays/production/postgresql/kustomization.yaml
@@ -6,10 +6,11 @@ metadata:
 
 namespace: postgresql-prod
 
-commonLabels:
-  app.kubernetes.io/instance: production-postgresql
-  environment: production
-  team: devops
+labels:
+- pairs:
+    app.kubernetes.io/instance: production-postgresql
+    environment: production
+    team: devops
 
 resources:
   - ../../../base/postgresql

--- a/k8s/overlays/staging/postgresql/kustomization.yaml
+++ b/k8s/overlays/staging/postgresql/kustomization.yaml
@@ -6,10 +6,11 @@ metadata:
 
 namespace: postgresql-staging
 
-commonLabels:
-  app.kubernetes.io/instance: staging-postgresql
-  environment: staging
-  team: devops
+labels:
+- pairs:
+    app.kubernetes.io/instance: staging-postgresql
+    environment: staging
+    team: devops
 
 resources:
   - ../../../base/postgresql


### PR DESCRIPTION
Fixed all deprecated commonLabels in Kubernetes YAML files.

  Changed in 4 files:
  - k8s/base/postgresql/kustomization.yaml
  - k8s/base/prometheus/kustomization.yaml
  - k8s/overlays/staging/postgresql/kustomization.yaml
  - k8s/overlays/production/postgresql/kustomization.yaml

  What was changed:
  # Before (deprecated)
  commonLabels:
    key: value

  # After (current syntax)
  labels:
  - pairs:
      key: value

  All deprecated commonLabels fields have been replaced with the current labels syntax.