### PR TITLE
fix: correct External Secrets readiness probes for local deployment

### DIFF
--- a/k8s/overlays/local/external-secrets/deployment-patch.yaml
+++ b/k8s/overlays/local/external-secrets/deployment-patch.yaml
@@ -19,3 +19,9 @@ spec:
         - --concurrent=1
         - --metrics-addr=:8080
         - --loglevel=debug
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/k8s/overlays/local/external-secrets/kustomization.yaml
+++ b/k8s/overlays/local/external-secrets/kustomization.yaml
@@ -15,6 +15,25 @@ patches:
     kind: Deployment
     name: external-secrets
 - target:
+    kind: Deployment
+    name: external-secrets-webhook
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/volumes/0
+      value:
+        name: certs
+        secret:
+          secretName: external-secrets-webhook
+    - op: replace
+      path: /spec/template/spec/containers/0/ports/2
+      value:
+        containerPort: 8081
+        name: healthz
+        protocol: TCP
+    - op: replace
+      path: /spec/template/spec/containers/0/readinessProbe/httpGet/path
+      value: /healthz
+- target:
     kind: ClusterSecretStore
     name: vault-backend
   patch: |-


### PR DESCRIPTION
## Summary
Fixed External Secrets Operator readiness probe issues in local minikube deployment.

## Changes
- **Main Controller**: Changed readiness probe endpoint from `/readyz` to `/healthz` on port `healthz` (8082)
- **Webhook**: 
  - Configured volume to mount TLS certificate from secret instead of emptyDir
  - Updated healthz port from 8082 to 8081 to match actual service configuration
  - Changed readiness probe path from `/readyz` to `/healthz`

## Testing
- All External Secrets pods now report 1/1 Ready
- Secret synchronization fully operational (5/5 ExternalSecrets synced)
- Main controller successfully syncing secrets from Vault
- Webhook and cert-controller functional

## Impact
- Resolves CrashLoopBackOff and readiness failures in local environment
- No impact on secret management functionality
- Local development environment now fully operational